### PR TITLE
Make the MongoDB logger play nice with Log::Async

### DIFF
--- a/lib/MongoDB/Log.pm6
+++ b/lib/MongoDB/Log.pm6
@@ -3,6 +3,8 @@ use v6;
 use Terminal::ANSIColor;
 use Log::Async;
 
+my $logger;
+
 #------------------------------------------------------------------------------
 package MongoDB:auth<github:MARTIMM> {
 
@@ -131,7 +133,7 @@ package MongoDB:auth<github:MARTIMM> {
       self.close-taps;
       for $!send-to-setup.keys -> $k {
         if ? $!send-to-setup{$k}[LOGCODE] {
-          logger.send-to(
+          $logger.send-to(
             $!send-to-setup{$k}[LOGOUTPUT],
             :code($!send-to-setup{$k}[LOGCODE]),
             :level($!send-to-setup{$k}[LOGLEVEL])
@@ -139,7 +141,7 @@ package MongoDB:auth<github:MARTIMM> {
         }
 
         else {
-          logger.send-to(
+          $logger.send-to(
             $!send-to-setup{$k}[LOGOUTPUT],
             :level($!send-to-setup{$k}[LOGLEVEL])
           );
@@ -151,7 +153,7 @@ package MongoDB:auth<github:MARTIMM> {
     # send-to method
     multi method send-to ( IO::Handle:D $fh, Code:D :$code!, |args ) {
 
-      logger.add-tap( -> $m { $m<fh> = $fh; $code($m); }, |args);
+      $logger.add-tap( -> $m { $m<fh> = $fh; $code($m); }, |args);
     }
 
     #--------------------------------------------------------------------------
@@ -185,7 +187,7 @@ package MongoDB:auth<github:MARTIMM> {
 }
 
 #------------------------------------------------------------------------------
-set-logger(MongoDB::Log.new());
+$logger = MongoDB::Log.new();
 
 #------------------------------------------------------------------------------
 class X::MongoDB is Exception {
@@ -289,32 +291,32 @@ my Code $log-code = sub (
 
 #------------------------------------------------------------------------------
 sub trace-message ( Str $msg ) is export {
-  logger.log( :$msg, :level(MongoDB::Trace), :code($log-code));
+  $logger.log( :$msg, :level(MongoDB::Trace), :code($log-code));
 }
 
 #------------------------------------------------------------------------------
 sub debug-message ( Str $msg ) is export {
-  logger.log( :$msg, :level(MongoDB::Debug), :code($log-code));
+  $logger.log( :$msg, :level(MongoDB::Debug), :code($log-code));
 }
 
 #------------------------------------------------------------------------------
 sub info-message ( Str $msg ) is export {
-  logger.log( :$msg, :level(MongoDB::Info), :code($log-code));
+  $logger.log( :$msg, :level(MongoDB::Info), :code($log-code));
 }
 
 #------------------------------------------------------------------------------
 sub warn-message ( Str $msg ) is export {
-  logger.log( :$msg, :level(MongoDB::Warn), :code($log-code-cf));
+  $logger.log( :$msg, :level(MongoDB::Warn), :code($log-code-cf));
 }
 
 #------------------------------------------------------------------------------
 sub error-message ( Str $msg ) is export {
-  logger.log( :$msg, :level(MongoDB::Error), :code($log-code-cf));
+  $logger.log( :$msg, :level(MongoDB::Error), :code($log-code-cf));
 }
 
 #------------------------------------------------------------------------------
 sub fatal-message ( Str $msg ) is export {
-  logger.log( :$msg, :level(MongoDB::Fatal), :code($log-code-cf));
+  $logger.log( :$msg, :level(MongoDB::Fatal), :code($log-code-cf));
   sleep 0.5;
   die X::MongoDB.new( :message($msg));
 }
@@ -360,10 +362,10 @@ my Code $code = sub ( $m ) {
 };
 
 #------------------------------------------------------------------------------
-sub add-send-to ( |c ) is export { logger.add-send-to( |c, :$code); }
-sub modify-send-to ( |c ) is export { logger.modify-send-to( |c, :$code); }
-sub drop-send-to ( |c ) is export { logger.drop-send-to(|c); }
-sub drop-all-send-to ( ) is export { logger.drop-all-send-to(); }
+sub add-send-to ( |c ) is export { $logger.add-send-to( |c, :$code); }
+sub modify-send-to ( |c ) is export { $logger.modify-send-to( |c, :$code); }
+sub drop-send-to ( |c ) is export { $logger.drop-send-to(|c); }
+sub drop-all-send-to ( ) is export { $logger.drop-all-send-to(); }
 
 #------------------------------------------------------------------------------
 # activate some channels. Display messages only on error and fatal to the screen


### PR DESCRIPTION
This makes the mongo logger use a private instance of Log::Async (its subclass, actually), instead of using the singleton. This should prevent other code from interfering with mongo logging, and vice versa.

This fixes issue #29.